### PR TITLE
qstat replacement and qhist improvements

### DIFF
--- a/bin/qhist
+++ b/bin/qhist
@@ -72,8 +72,8 @@ def printjoblist(joblist, header=False, nlines=0, memorystat=['maxvmem']):
             ("jobnumber", 10),
             ("jobname", 25),
             ( "pe_taskid", 6),
-            ( "start_time", 25),
-            ("end_time", 25 ),
+            ( "start_time", 22),
+            ("end_time", 22 ),
             ("wallclock", 10),
             ( "slots", 7 )
         ]
@@ -111,6 +111,8 @@ def printjoblist(joblist, header=False, nlines=0, memorystat=['maxvmem']):
                     else:
                         new_value.append(f'{val:02d}')
                 value = ':'.join(new_value)
+            elif f.endswith('_time'):
+                value = value[:-4]
             value = value[:(w -1)]  # strip it if longer than field.
             s += f"{value}"
             pad = ' ' * (w - len(value))

--- a/bin/qhist
+++ b/bin/qhist
@@ -141,7 +141,7 @@ if __name__ == '__main__':
                         default=0,
                         help='max number of entries to display (default all)')
 
-    parser.add_argument('-m', '--memorystat', default='maxvmem', nargs=1,
+    parser.add_argument('-m', '--memorystat', default=['maxvmem'], nargs=1,
                         choices=['maxvmem', 'maxrss', 'both'],
                         help='The memory runtime statistics to be displayed. '
                              'Can be \'maxvmem\', \'maxrss\', or \'both\'. '

--- a/bin/qhist
+++ b/bin/qhist
@@ -96,11 +96,25 @@ def printjoblist(joblist, header=False, nlines=0, memorystat=['maxvmem']):
     for jobdict in joblist:
         s=""
         for (f, w) in fields:
-           value = jobdict[f]
-           value = value[:(w -1)]  # strip it if longer than field.
-           s += f"{value}"
-           pad = ' ' * (w - len(value))
-           s += pad
+            value = jobdict[f]
+            if f == 'wallclock':
+                value = int(float(value))
+                if value >= 86400:
+                    days = True
+                else:
+                    days = False
+                value = convert_seconds(value, days=days)
+                new_value = []
+                for i, val in enumerate(value):
+                    if i == 0:
+                        new_value.append(f'{val:2d}')
+                    else:
+                        new_value.append(f'{val:02d}')
+                value = ':'.join(new_value)
+            value = value[:(w -1)]  # strip it if longer than field.
+            s += f"{value}"
+            pad = ' ' * (w - len(value))
+            s += pad
         slist.append(s)
     if nlines > 0:
         slist = slist[:nlines]
@@ -108,6 +122,28 @@ def printjoblist(joblist, header=False, nlines=0, memorystat=['maxvmem']):
     out = '\n'.join(hlist + slist)
     out = out + '\n'
     return out
+
+
+def convert_seconds(seconds, days=False):
+    """Convert seconds to hours, minutes, and seconds.
+
+    Args:
+        seconds: integer. Number of seconds to be converted.
+        days: boolean. If True, a 4-member tuple is returned
+            with days.
+
+    Returns:
+        A tuple of 3 integers. Seconds converted to
+        hours, minutes, seconds. If days=True, then days is
+        included and a 4 member tuple is returned.
+    """
+    m, s = divmod(seconds, 60)
+    h, m = divmod(m, 60)
+    if days:
+        d, h = divmod(h, 24)
+        return d, h, m, s
+    else:
+        return h, m, s
 
 
 if __name__ == '__main__':

--- a/bin/qhist
+++ b/bin/qhist
@@ -42,6 +42,8 @@ def parse_output(lines):
                 current["end_time"] = value
             elif key == "maxvmem":
                 current["maxvmem"] = value
+            elif key == "maxrss":
+                current["maxrss"] = value
             elif key == "pe_taskid":
                 current["pe_taskid"] = value
             elif key == "submit_cmd":
@@ -61,18 +63,23 @@ def get_history(days=1, user=get_username()):
     return joblist
 
 
-def printjoblist(joblist, header=False, nlines=0):
+def printjoblist(joblist, header=False, nlines=0, memorystat=['maxvmem']):
 #    fields = ["jobnumber", "jobname", "pe_taskid", "ru_wallclock", "slots", "maxvmem", "exit_status","submit_cmd"  ]
-    fields = [ ("jobnumber", 10),
-               ("jobname", 25),
-               ( "pe_taskid", 6),
-               ( "start_time", 25),
-               ("end_time", 25 ),
-               ("wallclock", 10),
-               ( "slots", 4 ),
-               ( "maxvmem", 10),
-               ( "exit_status", 6 )
-               ]
+    if memorystat == ['both']:
+        memorystat = ['maxvmem', 'maxrss']
+    fields = (
+        [
+            ("jobnumber", 10),
+            ("jobname", 25),
+            ( "pe_taskid", 6),
+            ( "start_time", 25),
+            ("end_time", 25 ),
+            ("wallclock", 10),
+            ( "slots", 7 )
+        ]
+        + list(zip(memorystat, [10]*len(memorystat)))
+        + [( "exit_status", 6 )]
+    )
     hlist = []
     slist = []
     if header:
@@ -134,10 +141,17 @@ if __name__ == '__main__':
                         default=0,
                         help='max number of entries to display (default all)')
 
+    parser.add_argument('-m', '--memorystat', default='maxvmem', nargs=1,
+                        choices=['maxvmem', 'maxrss', 'both'],
+                        help='The memory runtime statistics to be displayed. '
+                             'Can be \'maxvmem\', \'maxrss\', or \'both\'. '
+                             'maxvmem refers to virtual memory usage; '
+                             'maxrss refers to physical memory usage.')
+
     args= parser.parse_args()
 
     joblist = get_history(days=args.days)
-    out = printjoblist(joblist, args.header, args.nlines)
+    out = printjoblist(joblist, args.header, args.nlines, args.memorystat)
     try:
         sys.stdout.write(out)
     except IOError as e:

--- a/bin/qhist
+++ b/bin/qhist
@@ -39,7 +39,7 @@ def parse_output(lines):
             elif key == "start_time":
                 current["start_time"] = value
             elif key == "end_time":
-                current["end_time"] = value            
+                current["end_time"] = value
             elif key == "maxvmem":
                 current["maxvmem"] = value
             elif key == "pe_taskid":
@@ -47,7 +47,7 @@ def parse_output(lines):
             elif key == "submit_cmd":
                 current["submit_cmd"] = value
 
-    return lod    
+    return lod
 
 
 def get_history(days=1, user=get_username()):
@@ -79,8 +79,8 @@ def printjoblist(joblist, header=False, nlines=0):
         s=""
         for (f, w) in fields:
            value = f
-           value = value[:(w -1)]  # strip it if longer than field. 
-           s += f"{value}" 
+           value = value[:(w -1)]  # strip it if longer than field.
+           s += f"{value}"
            pad = ' ' * (w - len(value))
            s += pad
         hlist.append(s)
@@ -90,14 +90,14 @@ def printjoblist(joblist, header=False, nlines=0):
         s=""
         for (f, w) in fields:
            value = jobdict[f]
-           value = value[:(w -1)]  # strip it if longer than field. 
-           s += f"{value}" 
+           value = value[:(w -1)]  # strip it if longer than field.
+           s += f"{value}"
            pad = ' ' * (w - len(value))
            s += pad
         slist.append(s)
     if nlines > 0:
         slist = slist[:nlines]
-    
+
     out = '\n'.join(hlist + slist)
     out = out + '\n'
     return out
@@ -107,42 +107,42 @@ if __name__ == '__main__':
     # FORMAT='%(asctime)s (UTC) [ %(levelname)s ] %(filename)s:%(lineno)d %(name)s.%(funcName)s(): %(message)s'
     # logging.basicConfig(format=FORMAT)
     parser = argparse.ArgumentParser()
-      
-    # parser.add_argument('-d', '--debug', 
-    #                     action="store_true", 
-    #                     dest='debug', 
+
+    # parser.add_argument('-d', '--debug',
+    #                     action="store_true",
+    #                     dest='debug',
     #                     help='debug logging')
 
-    # parser.add_argument('-v', '--verbose', 
-    #                     action="store_true", 
-    #                     dest='verbose', 
+    # parser.add_argument('-v', '--verbose',
+    #                     action="store_true",
+    #                     dest='verbose',
     #                     help='verbose logging')
 
-    parser.add_argument('-D','--days', 
-                        metavar='days', 
+    parser.add_argument('-D','--days',
+                        metavar='days',
                         type=int,
-                        default=7, 
+                        default=7,
                         help='days previous to query')
-    
+
     parser.add_argument('-H', '--header',
                         action='store_true',
                         dest='header',
                         help='print column headers before output')
-    
+
     parser.add_argument('-n', '--nlines',
                         type=int,
                         default=0,
                         help='max number of entries to display (default all)')
-   
-    args= parser.parse_args()    
-    
+
+    args= parser.parse_args()
+
     joblist = get_history(days=args.days)
     out = printjoblist(joblist, args.header, args.nlines)
     try:
         sys.stdout.write(out)
     except IOError as e:
         pass
-    
 
-    
-    
+
+
+

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -69,7 +69,7 @@ def get_jobs():
                            f'{qstat.returncode}\n\n{qstat.stderr}')
     output = [line for line in qstat.stdout.splitlines() if line != '']
     if not output:
-        return []
+        return [], []
     del output[0]
     if ''.join(list(set(list(output[0])))) == '-':
         del output[0]

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -249,7 +249,7 @@ def main(usage, memorystats=['maxvmem'], njobs=0):
     (header, header_widths,
      run_state_ref, memory_labels) = get_constants(usage, memorystats)
     job_ids, run_states = get_jobs()
-    if len(job_ids) == 1:
+    if len(job_ids) == 0:
         return  # No qstat output
     try:
         print(header)

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -1,4 +1,4 @@
-#!/grid/gillis/home/nfox/software/python3.9.5/bin/python
+#!/usr/bin/env python
 
 """
 Author: Nathan Fox <nchristopherfox@gmail.com>

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -256,8 +256,11 @@ def main(usage, memorystats=['maxvmem']):
         # No qstat output
         return
     else:
-        print('\n'.join(records))
-        print()
+        try:
+            print('\n'.join(records))
+            print()
+        except BrokenPipeError:
+            return
 
 
 if __name__ == '__main__':

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -219,7 +219,7 @@ def main(usage):
         return
     else:
         print('\n'.join(records))
-        print('\n')
+        print()
 
 
 if __name__ == '__main__':

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -1,0 +1,232 @@
+#!/grid/gillis/home/nfox/software/python3.9.5/bin/python
+
+"""
+Author: Nathan Fox <nchristopherfox@gmail.com>
+Modified: 2021-06-25
+"""
+
+import subprocess
+
+
+def get_constants(usage):
+    """Get formatting constants.
+
+    Args:
+        usage: bool. If True, add wall clock and max mem usage.
+
+    Returns:
+        Tuple of 3. Header string (including horizontal span separator),
+        list of header fields and column widths, dict to translate
+        qstat job states to qqstat job states.
+    """
+    header_widths = [
+        ('owner', 8),
+        ('job ID', 10),
+        ('job name', 25),
+        ('job state', 13),
+        ('start(r)/submit(q)', 20),
+        ('memory', 8),
+        ('threads', 7)
+    ]
+    if usage:
+        header_widths += [('wall clock', 12), ('max mem', 6)]
+    header = '  '.join([f'{name:{width}s}' for name, width in header_widths])
+    header = header + '\n' + '-' * len(header)
+    run_state = {
+        'r': 'running',
+        't': 'transferring',
+        'R': 'restarting',
+        's': 'suspended',
+        'S': 'suspended',
+        'T': 'T',
+        'w': 'waiting',
+        'h': 'on hold',
+        'e': 'error',
+        'q': 'queued'
+    }
+    return header, header_widths, run_state
+
+
+def get_jobs():
+    """Get the list of job_ids returned by qstat.
+
+    Returns:
+        List of job_ids as strings.
+
+    Raises:
+        RuntimeError: If qstat system call fails.
+    """
+    qstat = subprocess.run(['qstat'], capture_output=True, text=True)
+    if qstat.returncode != 0:
+        raise RuntimeError('qstat returned a non-zero exit code: '
+                           f'{qstat.returncode}\n\n{qstat.stderr}')
+    output = [line for line in qstat.stdout.splitlines() if line != '']
+    if not output:
+        return []
+    del output[0]
+    if ''.join(list(set(list(output[0])))) == '-':
+        del output[0]
+    job_ids = [line.split()[0].strip() for line in output]
+    return job_ids
+
+
+def get_job_data(job_id):
+    """Get data for specific job.
+
+    Args:
+        job_id: str. ID of the job to query.
+
+    Returns:
+        dict of data for job_id, keyed by qstat field name.
+
+    Raises:
+        RuntimeError: If the job-specific qstat system call fails.
+    """
+    qstat = subprocess.run(['qstat', '-j', f'{job_id}'],
+                           capture_output=True, text=True)
+    if qstat.returncode != 0:
+        raise RuntimeError(f'\"{" ".join(qstat.args)}\" returned a '
+                           'non-zero exit code: '
+                           f'{qstat.returncode}\n\n{qstat.stderr}')
+    job_data = qstat.stdout.splitlines()
+    if ''.join(list(set(list(job_data[0])))) == '=':
+        del job_data[0]
+    # Concatenate env_list field that includes newlines
+    start_index = -1
+    end_index = -1
+    for i, rec in enumerate(job_data):
+        if rec.startswith('env_list'):
+            start_index = i
+        elif rec.startswith('job_args'):
+            end_index = i
+    job_data = (job_data[:start_index]
+                + ['\n'.join(job_data[start_index:end_index])]
+                + job_data[end_index:])
+    # Find column in which values begin
+    job_number_record = ''
+    for rec in job_data:
+        if rec.startswith('job_number'):
+            job_number_record = rec
+            break
+    value_index = -1
+    for i, c in enumerate(job_number_record):
+        if c.isnumeric():
+            value_index = i
+            break
+    if value_index == -1:
+        job_data_text = '\n'.join(job_data)
+        raise AssertionError(f'No "job_number" field in "qstat -j {job_id}"'
+                             f'\n\nRecord:\n{job_data_text}')
+    temp = {}
+    for jdata in job_data:
+        name = jdata[:value_index].split()[0].strip(' \t\n:')
+        value = jdata[value_index:].strip()
+        temp[name] = value
+    job_data = temp
+    return job_data
+
+
+def build_output_record(job_data, usage):
+    """Build output line for a job.
+
+    Args:
+        job_data: dict. Data for a specific job, keyed by qstat field name.
+        usage: bool. If True, add wall clock and max mem usage.
+
+    Returns:
+        String of the job data, formatted as a single pretty line.
+    """
+    header, header_widths, run_state = get_constants(usage)
+    # Choose time field and format job state
+    if 'start_time' in job_data:
+        time_entry = job_data['start_time'].split('.')[0]
+    elif 'submission_time' in job_data:
+        time_entry = job_data['submission_time'].split('.')[0]
+    else:
+        time_entry = ''
+    if job_data['job_state'] not in run_state:
+        run_state[job_data['job_state']]['state'] = job_data['job_state']
+
+    # Build output record
+    newr = {}
+    newr['owner'] = job_data['owner']
+    newr['job ID'] = job_data['job_number']
+    newr['job name'] = job_data['job_name']
+    newr['job state'] = run_state[job_data['job_state']]
+    newr['start(r)/submit(q)'] = time_entry
+    newr['threads'] = job_data['parallel'].split()[-1]
+    mem_value = []
+    mem_text = job_data['hard'].replace('m_mem_free=', '')
+    for i, c in enumerate(mem_text):
+        if c.isnumeric() or c == '.':
+            mem_value.append(c)
+        else:
+            break
+    mem_value = float(''.join(mem_value)) * float(newr['threads'])
+    newr['memory'] = f'{mem_value:.1f} {mem_text[i:]}'
+    if usage:
+        if newr['job state'] == 'running':
+            runstats = {}
+            for rs in job_data['usage'].split(', '):
+                stat, value = rs.split('=')
+                runstats[stat] = value
+            newr['wall clock'] = runstats['wallclock']
+            if runstats['maxvmem'] == 'N/A':
+                newr['max mem'] = ''
+            else:
+                mem_value = []
+                for i, c in enumerate(runstats['maxvmem']):
+                    if c.isnumeric() or c == '.':
+                        mem_value.append(c)
+                    else:
+                        break
+                mem_value = float(''.join(mem_value))
+                newr['max mem'] = (f'{mem_value:.1f} '
+                                   f'{runstats["maxvmem"][i:]}')
+        else:
+            newr['wall clock'] = ''
+            newr['max mem'] = ''
+    newline = [f'{newr[name]:{width}s}' for name, width in header_widths]
+    newline = '  '.join(newline)
+    return newline
+
+
+def main(usage):
+    """Replacement for UGE qstat.
+
+    UGE qstat as a summary without args is poorly formatted
+    and somewhat unhelpful. This is a drop in for "qstat". It
+    does not support anything beyond vanilla "qstat" without
+    any arguments or flags. Includes useful fields and ignores
+    unimportant fields (in the author's opinion). The output is
+    also not as wide as qstat output. Without usage stats,
+    it is 91 characters wide, growing to 109 with usage stats.
+    qstat output is 147 characters wide.
+
+    Args:
+        usage: bool. If True, add wall clock and max mem usage.
+    """
+    header, header_widths, run_state = get_constants(usage)
+    records = [header]
+    job_ids = get_jobs()
+    for jid in job_ids:
+        job_data = get_job_data(jid)
+        newline = build_output_record(job_data, usage)
+        records.append(newline)
+    if len(records) == 1:
+
+        # No qstat output
+        return
+    else:
+        print('\n'.join(records))
+        print('\n')
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--usage', action='store_true',
+                        help='Includes current runtime information, e.g. '
+                             'wall clock, max memory.')
+    args = parser.parse_args()
+    main(args.usage)

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -97,7 +97,8 @@ def get_job_data(job_id):
     for i, rec in enumerate(job_data):
         if rec.startswith('env_list'):
             start_index = i
-        elif rec.startswith('job_args'):
+        elif 'OLDPWD' in rec:
+        # elif rec.startswith('job_args'):
             end_index = i
     job_data = (job_data[:start_index]
                 + ['\n'.join(job_data[start_index:end_index])]
@@ -144,26 +145,47 @@ def build_output_record(job_data, usage):
         time_entry = job_data['submission_time'].split('.')[0]
     else:
         time_entry = ''
-    if job_data['job_state'] not in run_state:
-        run_state[job_data['job_state']]['state'] = job_data['job_state']
+    # run_state[job_data['job_state']]['state'] = job_data['job_state']
+    if 'job_state' not in job_data:
+        run_state = ''
+    elif job_data['job_state'] not in run_state:
+        run_state = job_data['job_state']
+    else:
+        run_state = run_state[job_data['job_state']]
 
     # Build output record
     newr = {}
-    newr['owner'] = job_data['owner']
-    newr['job ID'] = job_data['job_number']
-    newr['job name'] = job_data['job_name']
-    newr['job state'] = run_state[job_data['job_state']]
-    newr['start(r)/submit(q)'] = time_entry
-    newr['threads'] = job_data['parallel'].split()[-1]
-    mem_value = []
-    mem_text = job_data['hard'].replace('m_mem_free=', '')
-    for i, c in enumerate(mem_text):
-        if c.isnumeric() or c == '.':
-            mem_value.append(c)
+    for jd, newrec in [('owner', 'owner'), ('job_number', 'job ID'),
+                       ('job_name', 'job name'), ('job_state', 'job state')]:
+        if jd in job_data:
+            newr[newrec] = job_data[jd]
         else:
-            break
-    mem_value = float(''.join(mem_value)) * float(newr['threads'])
-    newr['memory'] = f'{mem_value:.1f} {mem_text[i:]}'
+            newr[newrec] = ''
+    # newr['owner'] = job_data['owner']
+    # newr['job ID'] = job_data['job_number']
+    # newr['job name'] = job_data['job_name']
+    # newr['job state'] = run_state[job_data['job_state']]
+    newr['job state'] = run_state
+    newr['start(r)/submit(q)'] = time_entry
+    if 'parallel' in job_data:
+        newr['threads'] = job_data['parallel'].split()[-1]
+    else:
+        newr['threads'] = '1'
+    if 'hard' in job_data:
+        mem_value = []
+        mem_text = job_data['hard'].replace('m_mem_free=', '')
+        for i, c in enumerate(mem_text):
+            if c.isnumeric() or c == '.':
+                mem_value.append(c)
+            else:
+                break
+        if newr['threads'] == '':
+            mem_value = float(''.join(mem_value))
+        else:
+            mem_value = float(''.join(mem_value)) * float(newr['threads'])
+        newr['memory'] = f'{mem_value:.1f} {mem_text[i:]}'
+    else:
+        newr['memory'] = ''
     if usage:
         if newr['job state'] == 'running':
             runstats = {}

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -3,6 +3,8 @@
 """
 Author: Nathan Fox <nchristopherfox@gmail.com>
 Modified: 2021-06-25
+
+NOTE: This does not handle array jobs well.
 """
 
 import subprocess

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -225,7 +225,7 @@ def build_output_record(job_data, run_state, usage, memorystats):
     return newline
 
 
-def main(usage, memorystats=['maxvmem']):
+def main(usage, memorystats=['maxvmem'], njobs=0):
     """Replacement for UGE qstat.
 
     UGE qstat as a summary without args is poorly formatted
@@ -241,24 +241,29 @@ def main(usage, memorystats=['maxvmem']):
         usage: bool. If True, add wall clock and max mem usage.
         memorystats: list. Indicates the memory usage stats to be
             displayed if usage is True.
+        njobs: int. The maximum number of jobs to display.
+            A value <= 0 will return all available jobs.
     """
     if memorystats == ['both']:
         memorystats = ['maxvmem', 'maxrss']
     (header, header_widths,
      run_state_ref, memory_labels) = get_constants(usage, memorystats)
-    records = [header]
     job_ids, run_states = get_jobs()
-    for jid, run_state in zip(job_ids, run_states):
+    if len(job_ids) == 1:
+        return  # No qstat output
+    try:
+        print(header)
+    except BrokenPipeError:
+        return
+    if njobs <= 0:
+        njobs = len(job_ids)
+    for i, (jid, run_state) in enumerate(zip(job_ids, run_states)):
+        if i >= njobs:
+            return
         job_data = get_job_data(jid)
         newline = build_output_record(job_data, run_state, usage, memorystats)
-        records.append(newline)
-    if len(records) == 1:
-        # No qstat output
-        return
-    else:
         try:
-            print('\n'.join(records))
-            print()
+            print(newline)
         except BrokenPipeError:
             return
 
@@ -277,5 +282,8 @@ if __name__ == '__main__':
                              'virtual memory usage; maxrss refers to '
                              'physical memory usage. Ignored if --usage is '
                              'not passed.')
+    parser.add_argument('-n', '--njobs', default=0, type=int,
+                        help='Maximum number of jobs to display. Default is '
+                             'all jobs. A number <= 0 will default.')
     args = parser.parse_args()
-    main(args.usage, args.memorystats)
+    main(args.usage, args.memorystats, args.njobs)

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -97,11 +97,16 @@ def get_job_data(job_id):
     for i, rec in enumerate(job_data):
         if rec.startswith('env_list'):
             start_index = i
-        elif 'OLDPWD' in rec:
-        # elif rec.startswith('job_args'):
+    for i, rec in enumerate(job_data):
+        if i <= start_index:
+            continue
+        elif rec.startswith(' ') or rec.startswith('}'):
+            continue
+        else:
             end_index = i
+            break
     job_data = (job_data[:start_index]
-                + ['\n'.join(job_data[start_index:end_index])]
+                + [' '.join(job_data[start_index:end_index])]
                 + job_data[end_index:])
     # Find column in which values begin
     job_number_record = ''

--- a/bin/qqstat
+++ b/bin/qqstat
@@ -8,7 +8,7 @@ Modified: 2021-06-25
 import subprocess
 
 
-def get_constants(usage):
+def get_constants(usage, memorystats):
     """Get formatting constants.
 
     Args:
@@ -28,11 +28,15 @@ def get_constants(usage):
         ('memory', 8),
         ('threads', 7)
     ]
+    memory_labels = {'maxvmem': 'max virt_mem',
+                     'maxrss': 'max phys_mem'}
     if usage:
-        header_widths += [('wall clock', 12), ('max mem', 6)]
+        header_widths += [('wall clock', 12)]
+        for memstat in memorystats:
+            header_widths += [(memory_labels[memstat], 11)]
     header = '  '.join([f'{name:{width}s}' for name, width in header_widths])
     header = header + '\n' + '-' * len(header)
-    run_state = {
+    run_state_ref = {
         'r': 'running',
         't': 'transferring',
         'R': 'restarting',
@@ -42,16 +46,17 @@ def get_constants(usage):
         'w': 'waiting',
         'h': 'on hold',
         'e': 'error',
-        'q': 'queued'
+        'q': 'queued',
+        'qw': 'queued/wait'
     }
-    return header, header_widths, run_state
+    return header, header_widths, run_state_ref, memory_labels
 
 
 def get_jobs():
     """Get the list of job_ids returned by qstat.
 
     Returns:
-        List of job_ids as strings.
+        Tuple of two lists: job_ids and run_states as strings.
 
     Raises:
         RuntimeError: If qstat system call fails.
@@ -67,7 +72,8 @@ def get_jobs():
     if ''.join(list(set(list(output[0])))) == '-':
         del output[0]
     job_ids = [line.split()[0].strip() for line in output]
-    return job_ids
+    run_states = [line.split()[4].strip() for line in output]
+    return job_ids, run_states
 
 
 def get_job_data(job_id):
@@ -132,17 +138,19 @@ def get_job_data(job_id):
     return job_data
 
 
-def build_output_record(job_data, usage):
+def build_output_record(job_data, run_state, usage, memorystats):
     """Build output line for a job.
 
     Args:
         job_data: dict. Data for a specific job, keyed by qstat field name.
+        run_state: str. run_state of the job with job_data
         usage: bool. If True, add wall clock and max mem usage.
 
     Returns:
         String of the job data, formatted as a single pretty line.
     """
-    header, header_widths, run_state = get_constants(usage)
+    (header, header_widths,
+     run_state_ref, memory_labels) = get_constants(usage, memorystats)
     # Choose time field and format job state
     if 'start_time' in job_data:
         time_entry = job_data['start_time'].split('.')[0]
@@ -150,13 +158,10 @@ def build_output_record(job_data, usage):
         time_entry = job_data['submission_time'].split('.')[0]
     else:
         time_entry = ''
-    # run_state[job_data['job_state']]['state'] = job_data['job_state']
-    if 'job_state' not in job_data:
-        run_state = ''
-    elif job_data['job_state'] not in run_state:
-        run_state = job_data['job_state']
+    if run_state not in run_state_ref:
+        run_state = run_state  # No effect; here for readability
     else:
-        run_state = run_state[job_data['job_state']]
+        run_state = run_state_ref[run_state]
 
     # Build output record
     newr = {}
@@ -166,10 +171,6 @@ def build_output_record(job_data, usage):
             newr[newrec] = job_data[jd]
         else:
             newr[newrec] = ''
-    # newr['owner'] = job_data['owner']
-    # newr['job ID'] = job_data['job_number']
-    # newr['job name'] = job_data['job_name']
-    # newr['job state'] = run_state[job_data['job_state']]
     newr['job state'] = run_state
     newr['start(r)/submit(q)'] = time_entry
     if 'parallel' in job_data:
@@ -198,27 +199,31 @@ def build_output_record(job_data, usage):
                 stat, value = rs.split('=')
                 runstats[stat] = value
             newr['wall clock'] = runstats['wallclock']
-            if runstats['maxvmem'] == 'N/A':
-                newr['max mem'] = ''
-            else:
-                mem_value = []
-                for i, c in enumerate(runstats['maxvmem']):
-                    if c.isnumeric() or c == '.':
-                        mem_value.append(c)
-                    else:
-                        break
-                mem_value = float(''.join(mem_value))
-                newr['max mem'] = (f'{mem_value:.1f} '
-                                   f'{runstats["maxvmem"][i:]}')
+            for memstat in memorystats:
+                if memstat not in runstats:
+                    newr[memstat] = ''
+                elif runstats[memstat] == 'N/A':
+                    newr[memory_labels[memstat]] = ''
+                else:
+                    mem_value = []
+                    for i, c in enumerate(runstats[memstat]):
+                        if c.isnumeric() or c == '.':
+                            mem_value.append(c)
+                        else:
+                            break
+                    mem_value = float(''.join(mem_value))
+                    newr[memory_labels[memstat]] = (f'{mem_value:.1f} '
+                                                    f'{runstats[memstat][i:]}')
         else:
             newr['wall clock'] = ''
-            newr['max mem'] = ''
+            for memstat in memorystats:
+                newr[memory_labels[memstat]] = ''
     newline = [f'{newr[name]:{width}s}' for name, width in header_widths]
     newline = '  '.join(newline)
     return newline
 
 
-def main(usage):
+def main(usage, memorystats=['maxvmem']):
     """Replacement for UGE qstat.
 
     UGE qstat as a summary without args is poorly formatted
@@ -232,16 +237,20 @@ def main(usage):
 
     Args:
         usage: bool. If True, add wall clock and max mem usage.
+        memorystats: list. Indicates the memory usage stats to be
+            displayed if usage is True.
     """
-    header, header_widths, run_state = get_constants(usage)
+    if memorystats == ['both']:
+        memorystats = ['maxvmem', 'maxrss']
+    (header, header_widths,
+     run_state_ref, memory_labels) = get_constants(usage, memorystats)
     records = [header]
-    job_ids = get_jobs()
-    for jid in job_ids:
+    job_ids, run_states = get_jobs()
+    for jid, run_state in zip(job_ids, run_states):
         job_data = get_job_data(jid)
-        newline = build_output_record(job_data, usage)
+        newline = build_output_record(job_data, run_state, usage, memorystats)
         records.append(newline)
     if len(records) == 1:
-
         # No qstat output
         return
     else:
@@ -255,5 +264,13 @@ if __name__ == '__main__':
     parser.add_argument('--usage', action='store_true',
                         help='Includes current runtime information, e.g. '
                              'wall clock, max memory.')
+    parser.add_argument('-m', '--memorystats', default=['maxvmem'], nargs=1,
+                        choices=['maxvmem', 'maxrss', 'both'],
+                        help='If --usage is passed, the memory runtime '
+                             'statistics to be displayed. Can be \'maxvmem\', '
+                             '\'maxrss\', or \'both\'. maxvmem refers to '
+                             'virtual memory usage; maxrss refers to '
+                             'physical memory usage. Ignored if --usage is '
+                             'not passed.')
     args = parser.parse_args()
-    main(args.usage)
+    main(args.usage, args.memorystats)


### PR DESCRIPTION
Built a drop in replacement for vanilla "qstat". Doesn't support qstat with any flags or arguments. Just makes the default summary output prettier and only includes the fields that I think are worth including. Lightly tested.

Added an argument so you can choose which memory stat you want to see, and made the wallclock stat easier to read. Also accidentally trimmed a bunch of trailing whitespace from qhist.